### PR TITLE
Add web scraper for player-match data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,30 +2,30 @@
 # KEDRO PROJECT
 
 # ignore all local configuration
-data_science/conf/local/**
-!data_science/conf/local/.gitkeep
+**/conf/local/**
+!**/conf/local/.gitkeep
 
 # ignore potentially sensitive credentials files
-data_science/conf/**/*credentials*
+**/conf/**/*credentials*
 .kaggle
 
 # ignore everything in the following folders
-data_science/data/**
-data_science/logs/**
-data_science/references/**
-data_science/results/**
+**/data/**
+**/logs/**
+**/references/**
+**/results/**
 
 # except their sub-folders
-!data_science/data/**/
-!data_science/logs/**/
-!data_science/references/**/
-!data_science/results/**/
+!**/data/**/
+!**/logs/**/
+!**/references/**/
+!**/results/**/
 
 # also keep all .gitkeep files
 !.gitkeep
 
 # keep also the example dataset
-!data_science/data/01_raw/iris.csv
+!**/data/01_raw/iris.csv
 
 
 ##########################
@@ -134,8 +134,8 @@ target/
 .ipynb_checkpoints
 
 # IPython
-data_science/.ipython/profile_default/history.sqlite
-data_science/.ipython/profile_default/startup/README
+**/.ipython/profile_default/history.sqlite
+**/.ipython/profile_default/startup/README
 
 # pyenv
 .python-version
@@ -168,3 +168,5 @@ Untitled.ipynb
 # R PACKAGE
 
 .Rproj.user
+.RData
+.Rhistory

--- a/futboldata/.dockerignore
+++ b/futboldata/.dockerignore
@@ -1,1 +1,3 @@
 .Rproj.user
+.RData
+.Rhistory

--- a/futboldata/DESCRIPTION
+++ b/futboldata/DESCRIPTION
@@ -11,20 +11,22 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     BH,
+    binman,
     dplyr,
     devtools,
-    fitzRoy,
     plogr,
     plumber,
     progress,
     purrr,
+    RSelenium,
+    readr
     rvest,
     stringr,
-    tidyr
+    tidyr,
+    wdman
 Suggests:
     roxygen2,
     testthat,
 Remotes:
-    git@github.com:jimmyday12/fitzRoy.git,
     git@github.com:tidyverse/tidyr.git
 RoxygenNote: 6.1.1

--- a/futboldata/R/player_stats.R
+++ b/futboldata/R/player_stats.R
@@ -1,0 +1,155 @@
+require(RSelenium)
+
+scrape_player_stats <- function(driver = RSelenium::rsDriver(browser = "firefox")) {
+  clean_csv_strings <- function(player_name, csv_string) {
+    N_HEADER_ROWS = 2
+
+    csv_rows <- csv_string %>%
+      stringr::str_split(., "\n") %>%
+      unlist
+
+    csv_header_row <- csv_rows[1:N_HEADER_ROWS] %>%
+      purrr::map(~ stringr::str_split(., ",")) %>%
+      purrr::pmap(paste0) %>%
+      unlist %>%
+      c("Player", .) %>%
+      paste0(., collapse = ",")
+
+    csv_body_rows <-  csv_rows[(N_HEADER_ROWS + 1):length(rows)] %>%
+      purrr::map(~ paste0(player_name, ",", .)) %>%
+      unlist
+
+      paste0(c(csv_header_row, csv_body_rows), collapse = "\n")
+  }
+
+  get_href <- function(link_element) {
+    link_element$getElementAttribute("href")
+  }
+
+  scrape_individual_match_stats <- function(browser, player_match_labels) {
+    TO_CSV_BUTTON_SELECTOR <- paste0(
+      "#all_kitchen_sink_matchlogs .section_heading_text .hasmore li:nth-child(4) button"
+    )
+
+    browser$navigate(player_match_labels[["url"]])
+
+    # browser$findElement(using = "css", "#all_kitchen_sink_matchlogs .section_heading_text .hasmore li:nth-child(4) button")
+
+    # Need to execute JS to click the button because calling $clickElement()
+    # on the webElement object doesn't do anything. The selector is probably
+    # more specific than it needs to be, but there are lots of tables
+    # on these pages with similar markup, so there's a high risk
+    # of accidentally querying for more than one intends.
+    browser$executeScript(
+      paste0(
+        "document.querySelector('", TO_CSV_BUTTON_SELECTOR, "').click()"
+      )
+    )
+
+    # FBRef are inconsistent in identifying the resulting csv elements,
+    # using id="csv_ks_matchlogs_all" when there are matches
+    # from international competitions present and
+    # id="csv_ks_matchlogs_<some number>" when there are only matches
+    # from domestic competitions. Since whether a player will have
+    # international matches in a given season is variable, and we have no way
+    # of knowing what the ID will be, we select for the <pre> element
+    # and hope they don't start adding more than one to a page.
+    csv_elements <- browser$findElements(using = "css", "pre")
+    csv_element_count <- length(csv_elements)
+
+    if (length(csv_elements) > 1) {
+      stop(
+        paste0(
+          "Expected one <pre> element per page, but found ",
+          csv_element_count,
+          " on ",
+          browser$getCurrentUrl()
+        )
+      )
+    }
+
+    clean_csv_strings(
+      player_match_labels[["name"]],
+      csv_elements[[1]]$getElementText()
+    )
+  }
+
+  scrape_individual_player_stats <- function(browser, player_url) {
+    PLAYER_NAME_SELECTOR <- "h1[itemprop='name']"
+    # Selecting domestic leage matches only, because players don't always have
+    # matches in international competitions (e.g. Champions League),
+    # and I want to keep it relatively simple & consistent for now.
+    # Might include international matches sometime later.
+    DOMESTIC_COMPS_MATCH_LINK_SELECTOR <- "#all_stats_player [data-stat='matches'] a"
+
+    browser$navigate(player_url)
+
+    player_name <- browser$findElement(
+      using = "css", PLAYER_NAME_SELECTOR
+    )$getElementText()
+
+    match_urls <- browser$findElements(
+      using = "css", DOMESTIC_COMPS_MATCH_LINK_SELECTOR
+    ) %>%
+      purrr::map(get_href) %>%
+      unlist %>%
+      purrr::map(~ c(url = ., name = player_name))
+  }
+
+  PLAYER_STATS_URL = "https://fbref.com/en/comps/9/stats/Premier-League-Stats"
+  PLAYER_LINK_SELECTOR = "#stats_player [data-stat='player'] a"
+  STATS_COL_FILL = list(
+    Min = 0,
+    OffenseGls = 0,
+    OffenseAst = 0,
+    OffenseSh = 0,
+    OffenseSoT = 0,
+    OffenseCrs = 0,
+    OffenseFld = 0,
+    OffensePK = 0,
+    OffensePKatt = 0,
+    DefenseTkl = 0,
+    DefenseInt = 0,
+    DefenseFls = 0,
+    DefenseCrdY = 0,
+    DefenseCrdR = 0
+  )
+
+  browser <- driver$client
+
+  browser$navigate(PLAYER_STATS_URL)
+
+  stats <- browser$findElements(using = "css", PLAYER_LINK_SELECTOR) %>%
+    purrr::map(get_href) %>%
+    unlist %>%
+    purrr::map(~ scrape_individual_player_stats(browser, .)) %>%
+    unlist(., recursive = FALSE) %>%
+    purrr::map(~ scrape_individual_match_stats(browser, .)) %>%
+    purrr::map(readr::read_csv) %>%
+    purrr::map(
+      ~ dplyr::mutate(
+        .,
+        Min = as.numeric(Min),
+        OffenseGls = as.numeric(OffenseGls),
+        OffenseAst = as.numeric(OffenseAst),
+        OffenseSh = as.numeric(OffenseSh),
+        OffenseSoT = as.numeric(OffenseSoT),
+        OffenseCrs = as.numeric(OffenseCrs),
+        OffenseFld = as.numeric(OffenseFld),
+        OffensePK = as.numeric(OffensePK),
+        OffensePKatt = as.numeric(OffensePKatt),
+        DefenseTkl = as.numeric(DefenseTkl),
+        DefenseInt = as.numeric(DefenseInt),
+        DefenseFls = as.numeric(DefenseFls),
+        DefenseCrdY = as.numeric(DefenseCrdY),
+        DefenseCrdR = as.numeric(DefenseCrdR)
+      )
+    ) %>%
+    dplyr::bind_rows(.) %>%
+    tidyr::drop_na(., Date) %>%
+    tidyr::replace_na(., STATS_COL_FILL)
+
+  driver$server$stop()
+
+  stats
+}

--- a/futboldata/R/player_stats.R
+++ b/futboldata/R/player_stats.R
@@ -1,6 +1,7 @@
 require(RSelenium)
 
 scrape_player_stats <- function(driver = RSelenium::rsDriver(browser = "firefox")) {
+  print(Sys.time())
   # RSelenium silently fails when you tell it to navigate to a junk URL,
   # staying on the same page and resulting in a difficult-to-understand error
   # getting raised later
@@ -400,6 +401,7 @@ scrape_player_stats <- function(driver = RSelenium::rsDriver(browser = "firefox"
     dplyr::select(., -c("SeasonCompetition", "MatchReport"))
 
   # driver$server$stop()
+  print(Sys.time())
 
   stats
 }

--- a/futboldata/R/player_stats.R
+++ b/futboldata/R/player_stats.R
@@ -270,6 +270,14 @@ scrape_player_stats <- function(driver = RSelenium::rsDriver(browser = "firefox"
       # in one season
       unique
 
+    # Some older player pages don't have links to per-match data pages, so we
+    # just skip them. This seems to only happen with players whose final season
+    # was 2014-2015 (the first season with per-match data), but not sure if it
+    # applies to all players like this or just some.
+    if (is.null(match_urls)) {
+      return(NULL)
+    }
+
     comp_elements <- browser$findElements(
       using = "css", DOMESTIC_COMPS_COMP_LINK_SELECTOR
     )
@@ -355,6 +363,7 @@ scrape_player_stats <- function(driver = RSelenium::rsDriver(browser = "firefox"
   stats <- scrape_player_links(browser) %>%
     purrr::map(~ scrape_individual_player_stats(browser, .)) %>%
     unlist(., recursive = FALSE) %>%
+    purrr::discard(is.null) %>%
     purrr::map(~ scrape_individual_match_stats(browser, .)) %>%
     purrr::map(readr::read_csv) %>%
     purrr::map(

--- a/futboldata/R/plumber.R
+++ b/futboldata/R/plumber.R
@@ -1,4 +1,5 @@
 source(paste0(getwd(), "/R/hello.R"))
+source(paste0(getwd(), "/R/player_stats.R"))
 
 #' Say hello to somebody
 #' @param name Name of the recipient of the salutation
@@ -6,4 +7,11 @@ source(paste0(getwd(), "/R/hello.R"))
 function(name = "") {
   hello(name) %>%
     jsonlite::toJSON(.)
+}
+
+#' Fetch EPL player stats from fbref.com
+#' @get /player_stats
+function() {
+  scrape_player_stats %>%
+  jsonlite::toJSON(.)
 }


### PR DESCRIPTION
I couldn't get `rvest` to work due to weird HTML comments (SSR?) shenanigans preventing the parser from reaching the player data tables, so I implemented a scraper in `RSelenium`, which works, but when I try to do a full run, it triggers some sort of alert, which causes it to timeout. It also takes forever.

While googling alternatives in Python, I ran into similar issues, but came across a solution that I was able to get working in `rvest`: Use the xpath to the comments to capture the hidden data, clean up the string a little to make it valid HTML, then parse it as usual.

Rather than undoing most of the work on this branch, or adding a whole bunch of commits on top of it, I'd rather just merge it and start on a fresh branch to convert the Selenium browser scraping to low-level requests via `rvest`.