### PR TITLE
Nullify skipped_urls per API call

### DIFF
--- a/futboldata/R/plumber.R
+++ b/futboldata/R/plumber.R
@@ -8,6 +8,12 @@ source(paste0(getwd(), "/R/player_urls.R"))
 #' @param end_season Last season to scrape data for. Format: YYYY-YYYY.
 #' @get /player_urls
 function(start_season, end_season) {
+  assign(
+    "skipped_urls",
+    NULL,
+    envir = .GlobalEnv
+  )
+
   withCallingHandlers({
       scrape_player_links(start_season, end_season) %>%
       list(data = ., error = NULL)
@@ -27,6 +33,12 @@ function(start_season, end_season) {
 #' @param player_urls List of URLs to player pages.
 #' @get /player_stats
 function(player_urls) {
+  assign(
+    "skipped_urls",
+    NULL,
+    envir = .GlobalEnv
+  )
+
   withCallingHandlers({
       scrape_player_stats(player_urls) %>%
       list(data = ., error = NULL)


### PR DESCRIPTION
With `skipped_urls` being a global variable, it would hold onto the URLs from previous runs of the script if you didn't restart the server, so we now make sure that it's `NULL` at the start of every API call.